### PR TITLE
P0-2: RuntimeExecutionViewで読取経路を最小収束

### DIFF
--- a/doc/work/P0-1_ObserveToken_formalization_PR差分設計_2026-05-24.md
+++ b/doc/work/P0-1_ObserveToken_formalization_PR差分設計_2026-05-24.md
@@ -1,0 +1,161 @@
+# P0-1 ObserveToken formalization 専用PR 差分設計
+
+作成日: 2026-05-24
+対象ブランチ: `main`
+上位計画: `doc/work/bridge_runtime_migration_plan.md`
+厳守規約: `doc/work/ISR_Bridge_Runtime_AI_暴走防止規約.md`
+
+---
+
+## 1. このPRの責務（1PR=1責務）
+
+本PRの責務は **ObserveToken の責務形式化のみ** とする。
+
+- 許可: observe enter/exit と generation pin の責務明文化
+- 禁止: publish/retire/graph mutation/cache ownership の導入
+- 禁止: crossfade / retire / validator / CI ロジック変更
+
+---
+
+## 2. 変更しないこと（非スコープ固定）
+
+以下は本PRで変更しない。
+
+- Audio処理アルゴリズム
+- crossfade 遷移・遅延整合ロジック
+- RuntimePublicationCoordinator / RetireRuntime の挙動
+- `RuntimeGraph` の責務
+- cleanup 実行
+
+---
+
+## 3. 現行コード根拠（as-is）
+
+### 3.1 token 実体
+
+- `src/core/ObservedRuntime.h`
+  - `ObservedRuntime` は
+    - `EpochDomainReaderGuard guard`
+    - `const GlobalSnapshot* ptr`
+    - `ownerThreadId`
+    を保持する move-only オブジェクト
+
+### 3.2 生成点
+
+- `src/core/SnapshotCoordinator.h`
+  - `observeCurrentRuntime(int)` が `ObservedRuntime` を返す
+
+### 3.3 使用点
+
+- `src/audioengine/AudioEngine.h`
+  - `observeCurrentRuntime()` public API
+  - `RuntimePublishView` が `ObservedRuntime` を保持
+- `src/audioengine/AudioEngine.Processing.AudioBlock.cpp`
+  - Audio callback で `m_coordinator.observeCurrentRuntime(kAudioEpochReaderIndex)` を使用
+- `src/audioengine/AudioEngine.Snapshot.cpp` / `AudioEngine.Timer.cpp`
+  - control thread で observe 利用
+- `src/SpectrumAnalyzerComponent.cpp`
+  - UI thread で `engine.observeCurrentRuntime()` を使用
+
+---
+
+## 4. 差分方針（最小差分・非破壊）
+
+本PRは **挙動変更なし** を原則とし、型責務の形式化だけを行う。
+
+### 方針A（採用）: 互換エイリアス方式
+
+1. `ObservedRuntime` を現行どおり維持
+2. `ObserveToken` という概念名を型エイリアスで導入
+3. ドキュメントコメントで「許可責務 / 禁止責務」を明文化
+4. 既存呼び出し側のシグネチャ変更は実施しない
+
+この方式により、bridge runtime への影響をゼロに近づける。
+
+### 方針B（不採用）: 全呼び出し側の一括リネーム
+
+- 理由: 「1PR=1責務」「大規模置換禁止」に反するため不採用
+
+---
+
+## 5. 予定差分（ファイル単位）
+
+## 5.1 `src/core/ObservedRuntime.h`（変更）
+
+- 追加:
+  - `ObserveToken` 概念の型エイリアス（non-breaking）
+  - 責務コメント（許可/禁止）
+- 維持:
+  - move-only 制約
+  - owner thread 検査
+  - `get()` / `operator bool()` の挙動
+
+## 5.2 `src/core/SnapshotCoordinator.h`（変更候補）
+
+- 変更候補は最小2案。
+  - 案1: コメントのみ更新（API変更なし）
+  - 案2: `using ObserveToken = ...` を使った戻り値型の明示
+- 既存API互換を優先し、呼び出し側変更を発生させない案を採用
+
+## 5.3 `src/audioengine/AudioEngine.h`（変更しない / コメントのみ候補）
+
+- 実装・シグネチャ変更は行わない
+- 必要なら `observeCurrentRuntime()` の責務コメントを補強
+
+---
+
+## 6. 機械判定可能な完了条件
+
+P0-1完了は次の条件を満たすこと。
+
+1. `ObserveToken`（または同義型）の責務定義がコード上で明文化されている
+2. token 型に publish/retire/graph mutation/cache ownership 相当 API が追加されていない
+3. 既存 observe 呼び出し点の件数が増加していない（新規 observe path 追加 0）
+4. ビルド成功（Debug）
+
+---
+
+## 7. 検証計画（P0-1 PR内）
+
+1. 静的確認
+   - `ObservedRuntime` / `ObserveToken` の公開API差分を確認
+   - 呼び出し点増加の有無を検索で確認
+2. ビルド確認
+   - 既存 Debug ビルドタスクでコンパイル成功
+3. 診断確認
+   - 対象ファイルの diagnostics がゼロ
+
+---
+
+## 8. rollback 設計
+
+本PRは挙動非変更のため rollback は単純。
+
+- 方法: `ObservedRuntime.h` / `SnapshotCoordinator.h` の差分取り消し
+- 影響面: 型名コメント/エイリアスの除去のみ
+
+---
+
+## 9. レビュー観点（固定）
+
+1. observe固定（IR-A）を壊していないか
+2. runtime 挙動が変わっていないか
+3. dual authority 統制に影響を与えていないか
+4. 新規 mutable/state を増やしていないか
+5. purity志向の過剰抽象化を入れていないか
+
+---
+
+## 10. 実装順（このPR内）
+
+1. `ObservedRuntime.h` へ概念名と責務制約コメントを追加
+2. 必要最小限で `SnapshotCoordinator.h` の表現を整合
+3. 呼び出し側は原則無変更
+4. 機械判定項目・ビルド・診断を実施
+
+---
+
+## 11. 判断メモ
+
+P0-1は「ObserveToken formalization」であり、機能追加フェーズではない。
+したがって本PRは **構造定義の明文化だけ** で閉じる。

--- a/doc/work/P0-1_準拠監査メモ_PR貼付用_2026-05-24.md
+++ b/doc/work/P0-1_準拠監査メモ_PR貼付用_2026-05-24.md
@@ -1,0 +1,96 @@
+# P0-1 準拠監査メモ（PR貼付用）
+
+- 作成日: 2026-05-24
+- 対象PR: **P0-1 ObserveToken formalization**
+- 上位計画: `doc/work/bridge_runtime_migration_plan.md`
+- 詳細設計規約: `doc/work/ISR_Bridge_Runtime_AI_暴走防止規約.md`
+- 差分設計書: `doc/work/P0-1_ObserveToken_formalization_PR差分設計_2026-05-24.md`
+
+---
+
+## PR説明文（そのまま貼り付け可）
+
+### 目的
+
+本PRは `P0-1 ObserveToken formalization` のみを対象とし、
+bridge runtime の挙動を変えずに **observe token の責務境界を明文化** する。
+
+### 変更範囲（最小）
+
+- `src/core/ObservedRuntime.h`
+  - `ObserveToken` 概念コメント追加（許可責務 / 禁止責務）
+  - `using ObserveToken = ObservedRuntime;` を追加（non-breaking）
+  - 互換性 `static_assert` を追加
+- `src/core/SnapshotCoordinator.h`
+  - `observeCurrentRuntime()` まわりの責務コメント整合（コメントのみ）
+
+### 非変更（明示）
+
+- runtime publish/retire 挙動
+- crossfade / latency / generation / ownership 制御
+- RuntimeGraph の責務
+- validator / CI ロジック
+- cleanup
+
+### 規約準拠サマリ
+
+- 1PR=1責務: ✅
+- 動作変更と構造変更の混在なし: ✅（コメント＋型エイリアスのみ）
+- observe path増殖なし: ✅
+- bridge runtime一括置換なし: ✅
+- cleanup先行なし: ✅
+
+### 検証結果
+
+- 対象ファイル diagnostics: **No errors**
+- Debug build: **成功**
+
+### リスク/ロールバック
+
+- リスク: 低（挙動非変更）
+- ロールバック: 当該2ファイルの差分取り消しで復元可能
+
+---
+
+## P0-1 準拠チェックリスト（監査用）
+
+### A. スコープ遵守
+
+- [x] 変更責務は ObserveToken formalization のみ
+- [x] 変更ファイルは `ObservedRuntime.h` / `SnapshotCoordinator.h` の最小範囲
+- [x] 呼び出し側の一括リネーム・大規模置換なし
+
+### B. 規約遵守（`ISR_Bridge_Runtime_AI_暴走防止規約.md`）
+
+- [x] 「1PR=1責務」を満たす
+- [x] 動作変更と構造変更を混在していない
+- [x] observe path の新規増殖なし
+- [x] RuntimeGraph への責務逆流なし
+- [x] crossfade 領域に手を入れていない
+- [x] cleanup 先行実施なし
+
+### C. 技術的妥当性
+
+- [x] `ObservedRuntime` の既存挙動（`get()`, `operator bool()`, move-only）は不変
+- [x] `ObserveToken` は互換エイリアスで non-breaking
+- [x] publish / retire / mutation API を token 型へ追加していない
+
+### D. 検証
+
+- [x] 対象ファイル diagnostics がゼロ
+- [x] Debug build 成功
+- [x] 追加変更の副作用なし（対象外ファイルへの機能変更なし）
+
+---
+
+## エビデンス（貼付欄）
+
+- `git diff -- src/core/ObservedRuntime.h src/core/SnapshotCoordinator.h`
+- diagnostics: `ObservedRuntime.h` / `SnapshotCoordinator.h` = No errors
+- build task: `Debug Build (cmd env retry)` 成功
+
+---
+
+## 監査結論
+
+**P0-1 は詳細設計規約を満たしており、bridge runtime の挙動非変更で実装されている。**

--- a/doc/work/P0-2_RuntimeExecutionView_読取経路収束_PR差分設計_2026-05-24.md
+++ b/doc/work/P0-2_RuntimeExecutionView_読取経路収束_PR差分設計_2026-05-24.md
@@ -1,0 +1,94 @@
+# P0-2 RuntimeExecutionView 読取経路収束 専用PR 差分設計
+
+作成日: 2026-05-24  
+対象ブランチ: `feature/p0-1-observetoken-formalization` から派生  
+上位計画: `doc/work/bridge_runtime_migration_plan.md`  
+厳守規約: `doc/work/ISR_Bridge_Runtime_AI_暴走防止規約.md`
+
+---
+
+## 1. このPRの責務（1PR=1責務）
+
+本PRは **RuntimeExecutionView{snapshot, local} への読取経路収束** のみを扱う。
+
+- 許可: 読取経路の明示化・重複読取の削減・参照経路の整流
+- 禁止: publish/retire/crossfade/latency/ownership の挙動変更
+- 禁止: RuntimeGraph の責務追加
+
+---
+
+## 2. 非スコープ（変更禁止）
+
+- クロスフェード開始/完了条件
+- retire queue/epoch reclaim
+- validator/CI 仕様変更
+- cleanup（削除系）
+- mutable state の新設
+
+---
+
+## 3. 現状課題（P0-2観点）
+
+- `AudioEngine` 内で snapshot / runtime graph の読取が複数パターンで散在
+- observe path が明示的に統一されておらず、将来の逸脱点が増えやすい
+
+---
+
+## 4. 差分方針（最小・非破壊）
+
+1. 既存API互換を維持
+2. 読取経路を `RuntimeExecutionView` 相当の補助関数に寄せる
+3. 挙動変更は入れない（計算順序・条件分岐の意味は不変）
+
+---
+
+## 5. 変更候補ファイル（最小）
+
+- `src/audioengine/AudioEngine.h`（読取ヘルパーの整理）
+- `src/audioengine/AudioEngine.Processing.AudioBlock.cpp`（読取入口の統一）
+- 必要時のみ `AudioEngine.Processing.BlockDouble.cpp` を追従
+
+> 1PR=1責務のため、上記以外へ波及しないこと。
+
+---
+
+## 6. 機械判定可能な完了条件
+
+1. 新規 observe path 追加 0
+2. `RuntimeExecutionView` 経由読取の適用率が対象範囲で増加
+3. crossfade/retire 関連ロジック差分 0
+4. Debug build 成功
+
+---
+
+## 7. 検証計画
+
+- 検索確認: observe 呼び出し点の増減
+- 差分確認: crossfade / retire への変更混入なし
+- ビルド確認: Debug Build
+- 診断確認: 変更ファイル diagnostics 0
+
+---
+
+## 8. ロールバック
+
+- 変更ファイル限定で revert 可能
+- 挙動変更を持たない構造整流のみのため巻き戻し容易
+
+---
+
+## 9. レビュー観点（固定）
+
+1. callback中 snapshot固定（IR-A）を壊していないか
+2. observe path増殖を抑制できているか
+3. dual authority 暴走に繋がる変更がないか
+4. purity志向の過剰抽象化になっていないか
+
+---
+
+## 10. 実装順（このPR内）
+
+1. 読取入口の現状マップ作成（対象関数限定）
+2. 最小ヘルパー導入（必要最小限）
+3. 呼び出し置換（意味不変）
+4. 検証（検索/差分/build/diagnostics）

--- a/src/audioengine/AudioEngine.Processing.AudioBlock.cpp
+++ b/src/audioengine/AudioEngine.Processing.AudioBlock.cpp
@@ -109,9 +109,9 @@ void AudioEngine::getNextAudioBlock (const juce::AudioSourceChannelInfo& bufferT
     // Epoch tracking for lock-free Audio Thread safety
     convo::RCUReaderGuard rcuGuard(audioThreadRcuReader);
 
-    // RuntimePublishView は取得中の observed guard を保持する（control reader 側）。
-    const auto runtimePublishView = getRuntimePublishView();
-    const auto* runtimeGraph = runtimePublishView.graph;
+    // P0-2: 読取入口を RuntimeExecutionView へ収束。
+    const auto runtimeExecutionView = getRuntimeExecutionViewForAudioThread();
+    const auto* runtimeGraph = runtimeExecutionView.graph;
 
     const auto packHandle = [](convo::isr::DSPHandle handle) noexcept -> std::uint64_t
     {
@@ -179,8 +179,7 @@ void AudioEngine::getNextAudioBlock (const juce::AudioSourceChannelInfo& bufferT
         // Audio ThreadではAtomic変数の読み取りのみを行い、ロックやメモリ確保を伴う処理は行わない。
         // 構造変更が必要な場合は、別途フラグやUIスレッド経由で再構築を行う。
         // ── Audio Thread 最適化: GlobalSnapshot を優先し、fallback で atomics を読む ──
-        const auto observedSnapshot = m_coordinator.observeCurrentRuntime(kAudioEpochReaderIndex);
-        const convo::GlobalSnapshot* snap = observedSnapshot.get();
+        const convo::GlobalSnapshot* snap = runtimeExecutionView.snapshot;
         if (snap == nullptr)
         {
             bufferToFill.clearActiveBufferRegion();

--- a/src/audioengine/AudioEngine.Processing.BlockDouble.cpp
+++ b/src/audioengine/AudioEngine.Processing.BlockDouble.cpp
@@ -91,8 +91,8 @@ void AudioEngine::processBlockDouble (juce::AudioBuffer<double>& buffer)
         return;
     }
 
-    const auto runtimePublishView = getRuntimePublishView();
-    const auto* runtimeGraph = runtimePublishView.graph;
+    const auto runtimeExecutionView = getRuntimeExecutionViewForAudioThread();
+    const auto* runtimeGraph = runtimeExecutionView.graph;
     DSPCore* dsp = (runtimeGraph != nullptr && runtimeGraph->runtimeUuid != 0)
         ? static_cast<DSPCore*>(runtimeGraph->activeNode)
         : nullptr;
@@ -110,8 +110,7 @@ void AudioEngine::processBlockDouble (juce::AudioBuffer<double>& buffer)
     #endif
 
     // --- ProcessingStateを現行設計で初期化 ---
-    const auto observedSnapshot = m_coordinator.observeCurrentRuntime(kAudioEpochReaderIndex);
-    const convo::GlobalSnapshot* snap = observedSnapshot.get();
+    const convo::GlobalSnapshot* snap = runtimeExecutionView.snapshot;
     if (snap == nullptr)
     {
         buffer.clear();

--- a/src/audioengine/AudioEngine.h
+++ b/src/audioengine/AudioEngine.h
@@ -1181,6 +1181,28 @@ public:
         const convo::RuntimeGraph* graph = nullptr;
     };
 
+    struct RuntimeExecutionView
+    {
+        RuntimeExecutionView(RuntimePublishView&& runtimePublishIn,
+                             convo::ObservedRuntime&& observedSnapshotIn) noexcept
+            : runtimePublish(std::move(runtimePublishIn))
+            , observedSnapshot(std::move(observedSnapshotIn))
+            , graph(runtimePublish.graph)
+            , snapshot(observedSnapshot.get())
+        {
+        }
+
+        RuntimeExecutionView(const RuntimeExecutionView&) = delete;
+        RuntimeExecutionView& operator=(const RuntimeExecutionView&) = delete;
+        RuntimeExecutionView(RuntimeExecutionView&&) noexcept = default;
+        RuntimeExecutionView& operator=(RuntimeExecutionView&&) noexcept = default;
+
+        RuntimePublishView runtimePublish;
+        convo::ObservedRuntime observedSnapshot;
+        const convo::RuntimeGraph* graph = nullptr;
+        const convo::GlobalSnapshot* snapshot = nullptr;
+    };
+
     struct CrossfadePreparedSnapshot
     {
         bool pending = false;
@@ -1875,6 +1897,17 @@ public:
         // control reader が EpochDomain に参加した状態で runtime graph を参照する。
         const auto* world = runtimeStore.observe();
         return RuntimePublishView { m_epochDomain, kControlEpochReaderIndex, world != nullptr ? &world->graph : nullptr };
+    }
+
+    // P0-2: 読取経路収束用の軽量ビュー。
+    // 取得元は既存と同一（runtimeStore.observe + SnapshotCoordinator.observeCurrentRuntime）で、
+    // 挙動を変えずに読取入口のみを統一する。
+    inline RuntimeExecutionView getRuntimeExecutionViewForAudioThread() const noexcept
+    {
+        return RuntimeExecutionView {
+            getRuntimePublishView(),
+            m_coordinator.observeCurrentRuntime(kAudioEpochReaderIndex)
+        };
     }
 
     inline convo::RuntimeGraph makeRuntimeGraphState(const convo::EngineRuntime& state) const noexcept

--- a/src/core/ObservedRuntime.h
+++ b/src/core/ObservedRuntime.h
@@ -8,6 +8,20 @@
 
 namespace convo {
 
+// ObserveToken (P0-1 formalization)
+// ---------------------------------
+// 許可責務:
+// - EpochDomain reader guard を保持し、observe enter/exit をスコープ化する
+// - 現在スレッドに束縛された snapshot pointer を参照として提供する
+//
+// 禁止責務:
+// - publish / retire の実行
+// - RuntimeGraph mutation / repair
+// - cache ownership / lifetime 管理
+//
+// 注記:
+// - 本型は bridge runtime の統制トークンであり、挙動変更を伴わない。
+// - P0-1 では API 互換を維持し、ObservedRuntime を実体として残す。
 struct ObservedRuntime
 {
     explicit ObservedRuntime(EpochDomain& domain, int readerIndex) noexcept
@@ -39,5 +53,12 @@ struct ObservedRuntime
 
 static_assert(!std::is_copy_constructible_v<ObservedRuntime>);
 static_assert(std::is_move_constructible_v<ObservedRuntime>);
+
+// 概念名エイリアス（non-breaking）
+using ObserveToken = ObservedRuntime;
+
+static_assert(std::is_same_v<ObserveToken, ObservedRuntime>);
+static_assert(!std::is_copy_constructible_v<ObserveToken>);
+static_assert(std::is_move_constructible_v<ObserveToken>);
 
 } // namespace convo

--- a/src/core/SnapshotCoordinator.h
+++ b/src/core/SnapshotCoordinator.h
@@ -13,6 +13,11 @@
 
 namespace convo {
 
+// P0-1 ObserveToken formalization:
+// - SnapshotCoordinator は observe enter/exit をトークン化して返す責務のみを持つ。
+// - 実体型は ObservedRuntime（ObserveToken の互換エイリアス）を使用する。
+// - publish / retire / graph mutation / ownership 管理は本APIの責務外。
+
 // Audio Thread safe equal-power approximation (sin(pi/2*x), libm free)
 static inline float equalPowerSinApprox(float x) noexcept
 {
@@ -45,6 +50,10 @@ public:
         m_retire.reclaim(*m_epochDomain);
     }
 
+    // observeCurrentRuntime:
+    // - reader guard を保持した ObserveToken 相当（ObservedRuntime）を返す。
+    // - 呼び出し側は本トークン寿命内で snapshot を参照する。
+    // - 挙動は既存互換を維持し、P0-1 では型/意味の明文化のみを行う。
     ObservedRuntime observeCurrentRuntime(int readerIndex) const noexcept {
         ObservedRuntime observed(*m_epochDomain, readerIndex);
         // acquire: switchImmediate/publishNew の m_current release と HB し最新スナップを観測。
@@ -54,7 +63,7 @@ public:
 
     void switchImmediate(GlobalSnapshot* newSnap) noexcept {
         resetFadeStateAndRetireTarget();
-        // release: 新スナップを公開し、observeCurrent/updateFade の acquire と HB 。
+        // release: 新スナップを公開し、observeCurrentRuntime/updateFade の acquire と HB 。
         //          旧ポインタ回収は release で十分（publishNew と同一 NonRT スレッドから呼ぶ前提）。
         GlobalSnapshot* oldSnap = m_slots.exchangeCurrent(newSnap, std::memory_order_release);
         if (oldSnap) {


### PR DESCRIPTION
## 概要
P0-2として、Audio Threadの読取入口を`RuntimeExecutionView`へ最小差分で収束しました。

## 変更点
- `src/audioengine/AudioEngine.h`
  - `RuntimeExecutionView` 追加
  - `getRuntimeExecutionViewForAudioThread()` 追加
- `src/audioengine/AudioEngine.Processing.AudioBlock.cpp`
  - 読取入口を RuntimeExecutionView 経由へ置換
- `src/audioengine/AudioEngine.Processing.BlockDouble.cpp`
  - 読取入口を RuntimeExecutionView 経由へ置換

## 規約適合
- 1PR=1責務（P0-2専用）
- 既存取得源（`runtimeStore.observe` / `observeCurrentRuntime`）は不変
- 挙動変更なし（読取経路の整流のみ）

## 検証
- 対象3ファイルの診断: エラーなし
- Debugビルド: 再実行で成功